### PR TITLE
Expand TestBoard layout to fullscreen

### DIFF
--- a/src/ts/game/ui/test/TestBoard.vue
+++ b/src/ts/game/ui/test/TestBoard.vue
@@ -41,17 +41,30 @@ async function br3() {}
 
 <style scoped>
 .board {
-  width: 500px;
-  height: 500px;
-
-  border: 1px, solid, var(--line);
+  display: flex;
+  width: 100%;
+  height: 100%;
+  border: 1px solid var(--line);
   background: var(--bg-lv2);
 }
 
-.frame {
-  width: 800px;
-  height: 600px;
+:deep(.frame) {
+  width: 100vw;
+  height: 100vh;
+  left: 0 !important;
+  top: 0 !important;
   backdrop-filter: blur(10px);
   flex-direction: column;
+}
+
+:deep(.body) {
+  flex: 1;
+}
+
+:deep(.area) {
+  display: flex;
+  flex: 1;
+  align-items: stretch;
+  justify-content: stretch;
 }
 </style>


### PR DESCRIPTION
## Summary
- allow the TestBoard frame to occupy the full viewport when opened
- stretch the embedded board area so the full hex grid can display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ccc5b2d0832d9b627d5ec2d3918e