### PR TITLE
Add fullscreen toggle to test board view

### DIFF
--- a/src/ts/game/ui/test/TestBoard.vue
+++ b/src/ts/game/ui/test/TestBoard.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 // VUE
-import { ref, Ref ,toRefs} from "vue";
+import { ref, Ref ,toRefs, computed } from "vue";
 // OBJECT
 import { FrameProps } from "core/object/app";
 // UI
@@ -12,6 +12,33 @@ import Board from "game/ui/Board.vue";
 // PROPS
 const props = withDefaults(defineProps<FrameProps>(), {})
 const { options } = toRefs(props.frame!)
+
+const isFullscreen = ref(false)
+const originalPosition = ref({
+  left: options.value.left,
+  top: options.value.top,
+})
+
+const frameClass = computed(() => ({
+  fullscreen: isFullscreen.value,
+}))
+
+function toggleFullscreen() {
+  if (!isFullscreen.value) {
+    originalPosition.value = {
+      left: options.value.left,
+      top: options.value.top,
+    }
+    options.value.left = 0
+    options.value.top = 0
+    isFullscreen.value = true
+    return
+  }
+
+  options.value.left = originalPosition.value.left
+  options.value.top = originalPosition.value.top
+  isFullscreen.value = false
+}
 
 type Instance = InstanceType<typeof Board>;
 const mr: Ref<Instance | null> = ref(null);
@@ -27,12 +54,19 @@ async function br3() {}
 </script>
 
 <template>
-  <NFrame v-on="props.frame!.eventObject" :title="'Board'" :left="options.left" :top="options.top">
+  <NFrame
+    v-on="props.frame!.eventObject"
+    :title="'Board'"
+    :left="options.left"
+    :top="options.top"
+    :class="frameClass"
+  >
     <template #button>
       <button @click="br1()">空角色</button>
+      <button @click="toggleFullscreen">{{ isFullscreen ? '退出全屏' : '全屏' }}</button>
     </template>
     <template #ui>
-      <div class="board">
+      <div class="board" :class="{ 'board--fullscreen': isFullscreen }">
         <Board ref="mr"></Board>
       </div>
     </template>
@@ -41,11 +75,19 @@ async function br3() {}
 
 <style scoped>
 .board {
-  width: 500px;
-  height: 500px;
+  width: 100%;
+  height: 100%;
 
-  border: 1px, solid, var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border: 1px solid var(--line);
   background: var(--bg-lv2);
+}
+
+.board--fullscreen {
+  padding: 0;
 }
 
 .frame {
@@ -53,5 +95,21 @@ async function br3() {}
   height: 600px;
   backdrop-filter: blur(10px);
   flex-direction: column;
+}
+
+.frame.fullscreen {
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
+}
+
+:deep(.frame.fullscreen .area) {
+  justify-content: center;
+  align-items: stretch;
+}
+
+:deep(.frame.fullscreen .area > *) {
+  flex: 1;
 }
 </style>


### PR DESCRIPTION
## Summary
- add a fullscreen toggle to the test board frame that preserves and restores the previous window position
- expand the embedded board area to fill the frame and correct the border styling for better display

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: missing core/ui/Base/Select.vue import in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ccc5b2d0832d9b627d5ec2d3918e